### PR TITLE
fix(i18n): correct next/prev post URL for non-default locales

### DIFF
--- a/src/i18n/utils.test.ts
+++ b/src/i18n/utils.test.ts
@@ -10,6 +10,7 @@ import {
   getLocaleInfo,
   getLocaleMsgs,
   getRelativeLocalePath,
+  getSlugWithoutLocale,
   isLocaleKey,
   stripBaseAndLocale,
   translateFor,
@@ -148,6 +149,32 @@ describe("getRelativeLocalePath", () => {
 
   it("should return `/` if empty path `` supplied for default locale", () => {
     expect(getRelativeLocalePath(DEFAULT_LOCALE, "")).toBe("/");
+  });
+});
+
+describe("getSlugWithoutLocale", () => {
+  it("should remove the locale prefix from the slug", () => {
+    expect(getSlugWithoutLocale("ja/my-post")).toBe("my-post");
+  });
+
+  it("should return the original slug if no locale prefix is present", () => {
+    expect(getSlugWithoutLocale("my-post")).toBe("my-post");
+  });
+
+  it("should handle slugs with multiple slashes", () => {
+    expect(getSlugWithoutLocale("ja/category/my-post")).toBe(
+      "category/my-post"
+    );
+  });
+
+  it("should not remove parts of the slug that look like a locale", () => {
+    expect(getSlugWithoutLocale("not-a-locale/my-post")).toBe(
+      "not-a-locale/my-post"
+    );
+  });
+
+  it("should return the original slug for the default locale", () => {
+    expect(getSlugWithoutLocale("es/my-post")).toBe("my-post");
   });
 });
 

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -100,3 +100,14 @@ export function buildPrefix(
 
   return new URL(baseWithLocale, "http://foo.com").pathname;
 }
+
+export function getSlugWithoutLocale(slug: string) {
+  const slugParts = slug.split("/");
+  if (
+    slugParts.length > 1 &&
+    SUPPORTED_LOCALES.includes(slugParts[0] as LocaleKey)
+  ) {
+    return slugParts.slice(1).join("/");
+  }
+  return slug;
+}

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -12,13 +12,18 @@ import { getPath } from "@/utils/getPath";
 import { slugifyStr } from "@/utils/slugify";
 import IconChevronLeft from "@/assets/icons/IconChevronLeft.svg";
 import IconChevronRight from "@/assets/icons/IconChevronRight.svg";
-import { getRelativeLocalePath, translateFor } from "@/i18n/utils";
+import {
+  getRelativeLocalePath,
+  getSlugWithoutLocale,
+  translateFor,
+} from "@/i18n/utils";
 import { SITE } from "@/config";
 
 export interface Props {
   post: CollectionEntry<"blog">;
   posts: CollectionEntry<"blog">[];
 }
+
 const t = translateFor(Astro.currentLocale);
 
 const { post, posts } = Astro.props;
@@ -143,7 +148,7 @@ const nextPost =
           <a
             href={getRelativeLocalePath(
               Astro.currentLocale,
-              `/posts/${prevPost.slug}`
+              `/posts/${getSlugWithoutLocale(prevPost.slug)}`
             )}
             class="flex w-full gap-1 hover:opacity-75"
           >
@@ -160,7 +165,7 @@ const nextPost =
           <a
             href={getRelativeLocalePath(
               Astro.currentLocale,
-              `/posts/${nextPost.slug}`
+              `/posts/${getSlugWithoutLocale(nextPost.slug)}`
             )}
             class="flex w-full justify-end gap-1 text-right hover:opacity-75 sm:col-start-2"
           >


### PR DESCRIPTION
Resolves this [issue](https://github.com/yousef8/astro-paper-i18n/issues/17) "Next/Previous Post" links for non-default languages were generated with a duplicated locale prefix.

The root cause was that the post slug, derived from its file path (e.g., `ar/post-name`), already contained the locale. This slug was then passed to the `getRelativeLocalePath` utility, which prepended the locale again, leading to incorrect URLs like
`/ar/posts/ar/post-name`.

To fix this, a new `getSlugWithoutLocale` utility function has been created to strip the locale from the slug before generating the link. This function is centralized in `src/i18n/utils.ts` and is accompanied by a full suite of unit tests to ensure correctness.